### PR TITLE
Feat/add yaml subprocess definition support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,31 +76,55 @@ niri-screen-time -from=2023-10-01 -to=2023-10-31
 
 To track specific websites or console commands within applications, use the configuration file:
 
-**Location:**  
-`~/.config/niri-screen-time/subprograms.json`
+**Supported formats:** YAML (.yaml, .yml) or JSON (.json)
+**Location:**
+`~/.config/niri-screen-time/subprograms.{yaml,yml,json}`
+*Priority order: .yaml → .yml → .json*
 
 ##### Configuration Format
+**YAML:**
+```yaml
+- app_ids:
+    - application_identi1
+    - application_identi2
+  title_list:
+    - partial_window_title1
+    - partial_window_title2
+  alias: display_name
+```
+
+**JSON:**
 ```json
 [
   {
-    "app_id": [
+    "app_ids": [
         "application_identi1",
         "application_identi2"
     ],
-    "title": [
+    "title_list": [
         "partial_window_title1",
         "partial_window_title2",
     ],
     "alias": "display_name"
   }
 ]
-
 ```
 
 ##### Configuration Examples
 
 For terminal commands:
 
+**YAML:**
+```yaml
+- app_ids:
+    - com.mitchellh.ghostty
+  title_list:
+    - "NeoVim: ~/script/"
+    - "NeoVim: ~/.config"
+  alias: "NeoVim: edit configs"
+```
+
+**JSON:**
 ```json
 {
     "app_ids": [
@@ -116,6 +140,17 @@ For terminal commands:
 
 For websites in browser:
 
+**YAML:**
+```yaml
+- app_ids:
+    - zen
+    - app.zen_browser.zen
+  title_list:
+    - Monkeytype
+  alias: Monkeytype
+```
+
+**JSON:**
 ```json
 {
     "app_ids": [
@@ -130,6 +165,16 @@ For websites in browser:
 ```
 
 Just alias:
+
+**YAML:**
+```yaml
+- app_ids:
+    - org.gnome.Nautilus
+  title_list: []
+  alias: Nautilus
+```
+
+**JSON:**
 ```json
 {
     "app_ids": [

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.65.7 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,9 @@ golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0/go.mod h1:S9Xr4PYopiDyqSyp5N
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 modernc.org/libc v1.65.7 h1:Ia9Z4yzZtWNtUIuiPuQ7Qf7kxYrxP1/jeHZzG8bFu00=
 modernc.org/libc v1.65.7/go.mod h1:011EQibzzio/VX3ygj1qGFt5kMjP0lHb0qCW5/D/pQU=
 modernc.org/mathutil v1.7.1 h1:GCZVGXdaN8gTqB1Mf/usp1Y/hSqgI2vAGGP4jZMCxOU=

--- a/model/subProgram.go
+++ b/model/subProgram.go
@@ -1,7 +1,7 @@
 package model
 
 type SubProgram struct {
-	AppIDs    []string `json:"app_ids"`
-	TitleList []string `json:"title_list"`
-	Alias     string   `json:"alias"`
+	AppIDs    []string `json:"app_ids" yaml:"app_ids"`
+	TitleList []string `json:"title_list" yaml:"title_list"`
+	Alias     string   `json:"alias" yaml:"alias"`
 }

--- a/subprogrammanager/subProgram.go
+++ b/subprogrammanager/subProgram.go
@@ -8,11 +8,12 @@ import (
 	"strings"
 
 	"github.com/probeldev/niri-screen-time/model"
+	"gopkg.in/yaml.v3"
 )
 
 type SubProgramManager struct {
-	programs   []model.SubProgram
-	configPath string
+	programs  []model.SubProgram
+	configDir string
 }
 
 func NewSubProgramManager() (*SubProgramManager, error) {
@@ -21,10 +22,10 @@ func NewSubProgramManager() (*SubProgramManager, error) {
 		return nil, err
 	}
 
-	configPath := filepath.Join(homeDir, ".config", "niri-screen-time", "subprograms.json")
+	configDir := filepath.Join(homeDir, ".config", "niri-screen-time")
 
 	spm := &SubProgramManager{
-		configPath: configPath,
+		configDir: configDir,
 	}
 
 	if err := spm.loadPrograms(); err != nil {
@@ -35,18 +36,33 @@ func NewSubProgramManager() (*SubProgramManager, error) {
 }
 
 func (spm *SubProgramManager) loadPrograms() error {
-	file, err := os.ReadFile(spm.configPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
+	// Try YAML files first, then fall back to JSON
+	yamlExtensions := []string{".yaml", ".yml", ".json"}
+
+	for _, ext := range yamlExtensions {
+		configFile := filepath.Join(spm.configDir, "subprograms"+ext)
+		file, err := os.ReadFile(configFile)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return err
 		}
-		return err
+
+		if ext == ".json" {
+			if err := json.Unmarshal(file, &spm.programs); err != nil {
+				return err
+			}
+		} else {
+			if err := yaml.Unmarshal(file, &spm.programs); err != nil {
+				return err
+			}
+		}
+
+		return nil
 	}
 
-	if err := json.Unmarshal(file, &spm.programs); err != nil {
-		return err
-	}
-
+	// No configuration files found, return nil (not an error)
 	return nil
 }
 

--- a/subprogrammanager/subProgram.go
+++ b/subprogrammanager/subProgram.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/probeldev/niri-screen-time/model"
@@ -62,16 +63,13 @@ func (spm *SubProgramManager) loadPrograms() error {
 		return nil
 	}
 
-	// No configuration files found, return nil (not an error)
 	return nil
 }
 
 func (spm *SubProgramManager) IsSetProgram(st model.ScreenTime) bool {
 	for _, p := range spm.programs {
-		for _, id := range p.AppIDs {
-			if id == st.AppID {
-				return true
-			}
+		if slices.Contains(p.AppIDs, st.AppID) {
+			return true
 		}
 	}
 	return false


### PR DESCRIPTION
JSON sadly doesn't support comments, which would be helpful (at least for me) to keep track of a config file or to quickly enable and disable configs. 

No pressure to merge this, I can just keep a private fork. Would appreciate it, tho. 